### PR TITLE
fix: temporary server.pid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       TZ: America/Sao_Paulo
     env_file:
       - .env
-    command: bash -c "bin/setup && rails s -b 0.0.0.0"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/setup && rails s -b 0.0.0.0"
 
   db:
     image: postgres:14.5


### PR DESCRIPTION
O objetivo deste "pull request" é resolver o problema que acontece algumas vezes quando tentamos iniciar o projeto.

Segue a captura de tela evidenciando o erro:
![image](https://user-images.githubusercontent.com/85287720/233782666-8c1afa4a-06a2-468e-acc9-6f7f73b70201.png)

A solução sugerida é sempre remover "tmp/pids/server.pid" antes de tentar iniciar o back-end, conforme configurado no docker-compose.yml.